### PR TITLE
Add Baumbestand

### DIFF
--- a/sources.yml
+++ b/sources.yml
@@ -1,3 +1,10 @@
+- name: k_wfs_baumbestand
+  title: Baumbestand Berlin
+  url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_wfs_baumbestand
+  layer: 0
+  transparent: false
+
+Standard:	
 - name: topplus_web
   title: TopPlusOpen web
   url: http://sgx.geodatenzentrum.de/wms_topplus_open


### PR DESCRIPTION
Der Datenlayer mit den Bäumen wäre praktisch für OSM.

- Datensatz https://fbinter.stadt-berlin.de/fb/berlin/service_intern.jsp?id=k_wfs_baumbestand@senstadt&type=WMS
- Karte https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_wfs_baumbestand@senstadt&bbox=389125,5819208,390900,5820357

Wahrscheinlich klappt das so nicht. Wenn ich das System richtig verstehe, dann gibt es 4 Layer ("Ebenen"), richtig?

> Baumbestand Berlin - Straßenbäume ohne Datenbankeintrag
Baumbestand Berlin - Anlagenbäume ohne Datenbankeintrag
Baumbestand Berlin - Straßenbäume
Baumbestand Berlin - Anlagenbäume

Mit etwas rumfummeln, habe ich https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_wfs_baumbestand?REQUEST=GetCapabilities&SERVICE=WMS&VERSION=2.0.2 erzeugen können, was mir ein XML downloaded über das ich die Layer sehe.

Ich hatte gehofft, dort würde es einen "alle vier Layer"-Layer geben, der auch in der Webversion genutzt wird, aber den sehe ich da nicht.