### PR TITLE
Add areal images 2013

### DIFF
--- a/sources.yml
+++ b/sources.yml
@@ -64,6 +64,12 @@
   layer: 0
   transparent: false
 
+- name: '2013'
+  title: Digitale farbige Trueorthophotos 2013
+  url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild2013
+  layer: 0
+  transparent: false
+
 - name: '1953'
   title: Berlin 1953
   url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_luftbild1953


### PR DESCRIPTION
Es gibt keinen Download für diese Daten, so dass sie nicht über https://github.com/codeforberlin/tilestache-config bereitgestellt werden können. Aber im Mapproxy dürften sie funktionieren.

# Followup post deploy

- [ ] https://github.com/jochenklar/berlin-maps updaten
- [ ] https://github.com/jochenklar/berlin-aerial updaten

# Offizielle Informationen

https://fbinter.stadt-berlin.de/fb/berlin/service_intern.jsp?id=k_luftbild2013@senstadt&type=WMS
>
Kurzbeschreibung: | Digitales Trueorthophotomosaik für das gesamte Berliner Stadtgebiet mit einer Bodenauflösung von 0,20 m im Blattschnitt 2 km x 2 km.
-- | --
Koordinatensysteme: | EPSG:3068, EPSG:25833, EPSG:25832
Ausdehnung: | EPSG:3068: 2750,01, 250,01, 49780,01, 40100,01
  | EPSG:25833: 369097,85, 5799298,14, 416865,04, 5838236,21
  | EPSG:25832: 777914,96, 5805397,1, 822326,52, 5848208,6
Ebenen: | Digitale farbige Trueorthophotos 2013
Nutzungsbedingungen: | Für die Nutzung der Daten ist die Datenlizenz Deutschland - Namensnennung - Version 2.0 anzuwenden. Die Lizenz ist über https://www.govdata.de/dl-de/by-2-0 abrufbar. Der Quellenvermerk gemäß (2) der Lizenz lautet "Geoportal Berlin / [Titel des Datensatzes]".
Zugriffsbeschränkungen: | Es gelten keine Zugriffsbeschränkungen



https://fbinter.stadt-berlin.de/fb_daten/beschreibung/luftbild2013.html
>inhaltliche Erläuterungen
--
>Digitale farbige Trueorthophotos 2013
>
>Bei den Daten handelt es sich um farbige Digitale Trueorthophotomosaike [TDOP], die aus dem digitalen Bildflug August 2013 entstanden sind. Die differenziell entzerrten und im Koordinatensystem ETRS89/UTM33 erstellten TDOP haben eine Bodenauflösung von 0,20 Meter bei einer Lagegenauigkeit von +/- 20 Zentimeter
>
>Ein Trueorthofoto unterscheidet sich von einem herkömmlichen Orthofoto dadurch, dass alle Objekte, Gebäude, Brücken, Bäume etc. lagerichtig sind (das bedeutet lagerichtig nicht nur in der Ebene sondern auch in der Höhe, dadurch gibt es beispielsweise keine verklappten Gebäude)
