### PR TITLE
Update WMS request URL for layer baumbestand

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,20 +48,12 @@ layers:
     sources: [baumbestand_1_cache]
     title: Baumbestand Berlin - Anlagenbäume
 
-  - name: baumbestand_3
-    sources: [baumbestand_3_cache]
-    title: Baumbestand Berlin - Anlagenbäume ohne Datenbankeintrag
-
-  - name: baumbestand_4
-    sources: [baumbestand_4_cache]
-    title: Baumbestand Berlin - Straßenbäume ohne Datenbankeintrag
-
-  - name: baumbestand_0_1_3_4_merged
-    sources: [baumbestand_0_1_3_4_merged_cache]
+  - name: baumbestand_0_1_merged
+    sources: [baumbestand_0_1_merged_cache]
     title: Baumbestand Berlin - Straßenbäume und Anlagenbäume mit und ohne Datenbankeintrag
 
-  - name: baumbestand_0_1_3_4_alkis
-    sources: [baumbestand_0_1_3_4_alkis_cache]
+  - name: baumbestand_0_1_alkis
+    sources: [baumbestand_0_1_alkis_cache]
     title: Baumbestand Berlin - Straßenbäume und Anlagenbäume mit und ohne Datenbankeintrag, ALKIS Berlin s/w
 
   - name: k_oeffbeleucht_alkis
@@ -117,21 +109,13 @@ caches:
     grids: [mercator]
     sources: [baumbestand_1_source]
 
-  baumbestand_3_cache:
+  baumbestand_0_1_merged_cache:
     grids: [mercator]
-    sources: [baumbestand_3_source]
+    sources: [baumbestand_0_1_merged_source]
 
-  baumbestand_4_cache:
+  baumbestand_0_1_alkis_cache:
     grids: [mercator]
-    sources: [baumbestand_4_source]
-
-  baumbestand_0_1_3_4_merged_cache:
-    grids: [mercator]
-    sources: [baumbestand_0_1_3_4_merged_source]
-
-  baumbestand_0_1_3_4_alkis_cache:
-    grids: [mercator]
-    sources: [alkis_sw_cache, baumbestand_0_1_3_4_merged_cache]
+    sources: [alkis_sw_cache, baumbestand_0_1_merged_cache]
 
   k_oeffbeleucht_alkis_cache:
     grids: [mercator]
@@ -223,7 +207,7 @@ sources:
     type: wms
     wms_opts: { version: 1.3.0 }
 
-  baumbestand_anlagenbaeume_source:
+  baumbestand_0_source:
     req:
       format: png
       layers: anlagenbaeume
@@ -234,7 +218,7 @@ sources:
     type: wms
     wms_opts: { version: 1.3.0 }
 
-  baumbestand_strassenbaeume_source:
+  baumbestand_1_source:
     req:
       format: png
       layers: strassenbaeume
@@ -245,7 +229,7 @@ sources:
     type: wms
     wms_opts: { version: 1.3.0 }
 
-  baumbestand_anlagenbaeume_strassenbaeume_merged_source:
+  baumbestand_0_1_merged_source:
     req:
       format: png
       layers: anlagenbaeume,strassenbaeume

--- a/config.yml
+++ b/config.yml
@@ -223,57 +223,35 @@ sources:
     type: wms
     wms_opts: { version: 1.3.0 }
 
-  baumbestand_0_source:
+  baumbestand_anlagenbaeume_source:
     req:
       format: png
-      layers: 0
-      style: default
+      layers: anlagenbaeume
+      style: anlagenbaeume
       transparent: true
-      url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_wfs_baumbestand
+      url: https://gdi.berlin.de/services/wms/baumbestand
     supported_srs: ['EPSG:25833']
     type: wms
     wms_opts: { version: 1.3.0 }
 
-  baumbestand_1_source:
+  baumbestand_strassenbaeume_source:
     req:
       format: png
-      layers: 1
-      style: default
+      layers: strassenbaeume
+      style: strassenbaeume
       transparent: true
-      url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_wfs_baumbestand
+      url: https://gdi.berlin.de/services/wms/baumbestand
     supported_srs: ['EPSG:25833']
     type: wms
     wms_opts: { version: 1.3.0 }
 
-  baumbestand_3_source:
+  baumbestand_anlagenbaeume_strassenbaeume_merged_source:
     req:
       format: png
-      layers: 3
-      style: default
+      layers: anlagenbaeume,strassenbaeume
+      style: anlagenbaeume,strassenbaeume
       transparent: true
-      url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_wfs_baumbestand
-    supported_srs: ['EPSG:25833']
-    type: wms
-    wms_opts: { version: 1.3.0 }
-
-  baumbestand_4_source:
-    req:
-      format: png
-      layers: 4
-      style: default
-      transparent: true
-      url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_wfs_baumbestand
-    supported_srs: ['EPSG:25833']
-    type: wms
-    wms_opts: { version: 1.3.0 }
-
-  baumbestand_0_1_3_4_merged_source:
-    req:
-      format: png
-      layers: 0,1,3,4
-      style: default
-      transparent: true
-      url: https://fbinter.stadt-berlin.de/fb/wms/senstadt/k_wfs_baumbestand
+      url: https://gdi.berlin.de/services/wms/baumbestand
     supported_srs: ['EPSG:25833']
     type: wms
     wms_opts: { version: 1.3.0 }


### PR DESCRIPTION
This PR updates the WMS request URLs. The new source also uses different layer and style names, which this PR takes into account. All subsequent services that reference these layers must therefore also be adjusted.

Note: Since I am not currently running my own MapProxy, I was unable to test the new configuration. However, I tested the new service in QGis and checked the URLs used there.